### PR TITLE
Inline Slack text attachments

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -12,4 +12,30 @@ function formDataParser(req, res, next) {
     next();
 }
 
-module.exports = {formDataParser};
+// Chime webhooks use the `Content` field instead of `text`
+// This middleware just normalizes them by setting body.text to body.Content
+// if body.text is not available in the request body.
+function chimeParser(req, res, next) {
+    if (req.body.text) next();
+    if (req.body.Content) req.body.text = req.body.Content;
+    next();
+}
+
+// attachmentParser handles Slack webhook "attachments" of text format by inlining
+// them in the Wickr message
+function attachmentParser(req, res, next) {
+    if (req.body.attachments) {
+        try {
+            for (const attachment of req.body.attachments) {
+                if (attachment.text) {
+                    req.body.text += `\n\n-----\n\n${attachment.text}`;
+                }
+            }
+        } catch (e) {
+            console.log("Malformed attachment", e);
+        }
+    }
+    next();
+}
+
+module.exports = {formDataParser, chimeParser, attachmentParser};

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const morgan = require('morgan');
 
 const {NotFoundError, BadRequestError, HTTPError} = require('./errors');
-const {formDataParser} = require('./middleware');
+const {formDataParser, chimeParser, attachmentParser} = require('./middleware');
 
 module.exports = function createServer(bot) {
     let app = express();
@@ -17,16 +17,14 @@ module.exports = function createServer(bot) {
 
     app.get('/healthz', (req, res) => res.status(200).end());
 
-    app.post('/send/:key', formDataParser, async (req, res) => {
+    app.post('/send/:key', formDataParser, chimeParser, attachmentParser, async (req, res) => {
         try {
-            let body = req.body;
-            let text = body.text || body.Content;
-            if (!text) throw new BadRequestError('Missing message body');
+            if (!req.body.text) throw new BadRequestError('Missing message body');
 
             let vgroupid = bot.getVgroupForKey(req.params.key);
             if (!vgroupid) throw new NotFoundError();
 
-            bot.send(vgroupid, text);
+            bot.send(vgroupid, req.body.text);
             res.send("ok");
         } catch (e) {
             if (e instanceof HTTPError) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "wickrio-webhook-bot",
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
@@ -2142,9 +2143,9 @@
       }
     },
     "node_modules/nyc/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -5126,9 +5127,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -130,6 +130,40 @@ describe('server', function() {
                 });
         });
 
+        it('inlines text attachments', function(done) {
+            sinon.spy(this.bot, 'send');
+            request(this.app)
+                .post('/send/fakekey123')
+                .send('payload={"text":"hello world","attachments":[{"text":"zomg"},{"text":"wtf"},{"text":"bbq"}]}')
+                .set('Content-Type', 'application/x-www-form-urlencoded')
+                .expect(200)
+                .end((err, res) => {
+                    if (err) return done(err);
+                    expect(res.text).to.equal('ok');
+                    expect(this.bot.send.calledWith(
+                        'fakevgroup123', 'hello world\n\n-----\n\nzomg\n\n-----\n\nwtf\n\n-----\n\nbbq'
+                    )).to.be.true;
+                    return done();
+                });
+        });
+
+        it('handles malformed attachments', function(done) {
+            sinon.spy(this.bot, 'send');
+            request(this.app)
+                .post('/send/fakekey123')
+                .send({text: "hello world", attachments: true})
+                .set('Content-Type', 'application/json')
+                .expect(200)
+                .end((err, res) => {
+                    if (err) return done(err);
+                    expect(res.text).to.equal('ok');
+                    expect(this.bot.send.calledWith(
+                        'fakevgroup123', 'hello world'
+                    )).to.be.true;
+                    return done();
+                });
+        });
+
         it('responds with a 400 to form data requests without payload value', function(done) {
             request(this.app)
                 .post('/send/fakekey123')


### PR DESCRIPTION
The "attachments" fields provided in webhooks are now inlined into the
Wickr message instead of being ignored. Attachments are separated by
five hyphens (`-----`) which should be a horizontal rule, but we don't
quite support that Markdown feature in Wickr yet.